### PR TITLE
Remove space in extension list options as invalid

### DIFF
--- a/lib/core/ArgumentsParser.py
+++ b/lib/core/ArgumentsParser.py
@@ -164,7 +164,7 @@ class ArgumentsParser(object):
         mandatory = OptionGroup(parser, 'Mandatory')
         mandatory.add_option('-u', '--url', help='URL target', action='store', type='string', dest='url', default=None)
         mandatory.add_option('-L', '--url-list', help='URL list target', action='store', type='string', dest='urlList', default=None)
-        mandatory.add_option('-e', '--extensions', help='Extension list separated by comma (Example: php, asp)',
+        mandatory.add_option('-e', '--extensions', help='Extension list separated by comma (Example: php,asp)',
                              action='store', dest='extensions', default=None)
 
         connection = OptionGroup(parser, 'Connection Settings')


### PR DESCRIPTION
The options of dirs3arch include a space when specifying comma delimited extensions. The script needs extensions passed in without comma's. Just to help people that don't realise at first, I've removed the space in the help output.